### PR TITLE
fix(core): refactor function matchDate

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@andes/core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andes/core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/core/src/model-builder/index.spec.ts
+++ b/core/src/model-builder/index.spec.ts
@@ -124,9 +124,9 @@ describe('ReouserBase searching', () => {
             direccion: [
                 { tipo: 'laboral', calle: 'Santa Fe 670' }
             ],
-            fechaNacimiento: Date.now()
+            fechaNacimiento: new Date('1990-09-15 13:00:00')
         }, {} as any);
-        await personaResource.create({ nombre: 'Miguel Perez', active: true, fechaNacimiento: new Date('1990-08-01') }, {} as any);
+        await personaResource.create({ nombre: 'Miguel Perez', active: true, fechaNacimiento: new Date('1990-08-15 13:00:00') }, {} as any);
     });
 
     test('search exactly without result', async () => {
@@ -180,7 +180,32 @@ describe('ReouserBase searching', () => {
     });
 
     test('searching matchDate', async () => {
-        const search = await personaResource.search({ fechaNacimiento: '2019-11-01|2019-12-20' }, {}, {} as any);
+        const search = await personaResource.search({ fechaNacimiento: '1990-08-01|1990-08-31' }, {}, {} as any);
+        expect(search).toHaveLength(1);
+    });
+
+    test('searching matchDate', async () => {
+        const search = await personaResource.search({ fechaNacimiento: '1990-08-01|2019-12-20' }, {}, {} as any);
+        expect(search).toHaveLength(2);
+    });
+
+    test('searching matchDate: exact date without hour', async () => {
+        const search = await personaResource.search({ fechaNacimiento: '1990-08-15' }, {}, {} as any);
+        expect(search).toHaveLength(1);
+    });
+
+    test('searching matchDate: mayor a con hora', async () => {
+        const search = await personaResource.search({ fechaNacimiento: '>=1990-08-15T12:00:00' }, {}, {} as any);
+        expect(search).toHaveLength(2);
+    });
+
+    test('searching matchDate: menor a con hora', async () => {
+        const search = await personaResource.search({ fechaNacimiento: '<1990-08-15T12:00:00' }, {}, {} as any);
+        expect(search).toHaveLength(0);
+    });
+
+    test('searching matchDate: menor a con hora', async () => {
+        const search = await personaResource.search({ fechaNacimiento: '<1990-08-16T12:00:00' }, {}, {} as any);
         expect(search).toHaveLength(1);
     });
 });

--- a/core/src/model-builder/index.spec.ts
+++ b/core/src/model-builder/index.spec.ts
@@ -94,7 +94,8 @@ describe('ReouserBase searching', () => {
             active: Boolean,
             direccion: [
                 { tipo: String, calle: String }
-            ]
+            ],
+            fechaNacimiento: Date
         });
         PersonaModel = mongoose.model('personas_search', schema);
 
@@ -112,7 +113,8 @@ describe('ReouserBase searching', () => {
                 customField: {
                     field: 'direccion.calle',
                     fn: MongoQuery.partialString
-                }
+                },
+                fechaNacimiento: MongoQuery.matchDate
             };
         }
         personaResource = new Personas({});
@@ -121,9 +123,10 @@ describe('ReouserBase searching', () => {
             active: true,
             direccion: [
                 { tipo: 'laboral', calle: 'Santa Fe 670' }
-            ]
+            ],
+            fechaNacimiento: Date.now()
         }, {} as any);
-        await personaResource.create({ nombre: 'Miguel Perez', active: true }, {} as any);
+        await personaResource.create({ nombre: 'Miguel Perez', active: true, fechaNacimiento: new Date('1990-08-01') }, {} as any);
     });
 
     test('search exactly without result', async () => {
@@ -174,6 +177,11 @@ describe('ReouserBase searching', () => {
     test('searching with custom fields result', async () => {
         const search = await personaResource.search({ customField: '^santa' }, { fields: '-nombre' }, {} as any);
         expect(search[0].nombre).toBeUndefined();
+    });
+
+    test('searching matchDate', async () => {
+        const search = await personaResource.search({ fechaNacimiento: '2019-11-01|2019-12-20' }, {}, {} as any);
+        expect(search).toHaveLength(1);
     });
 });
 

--- a/core/src/query-builder/in-mongo.spec.ts
+++ b/core/src/query-builder/in-mongo.spec.ts
@@ -26,4 +26,31 @@ describe('Query Builder', () => {
         });
     });
 
+    it('matchDate: menor igual  ', () => {
+        const str = matchDate('<=2019-01-01');
+        expect(str).toMatchObject({
+            $lte: expect.any(Date),
+        });
+    });
+
+    it('matchDate: menor', () => {
+        const str = matchDate('<2019-01-01');
+        expect(str).toMatchObject({
+            $lt: expect.any(Date),
+        });
+    });
+
+    it('matchDate: mayor igual', () => {
+        const str = matchDate('>=2019-01-01');
+        expect(str).toMatchObject({
+            $gte: expect.any(Date),
+        });
+    });
+
+    it('matchDate: mayor', () => {
+        const str = matchDate('>2019-01-01');
+        expect(str).toMatchObject({
+            $gt: expect.any(Date),
+        });
+    });
 });

--- a/core/src/query-builder/in-mongo.spec.ts
+++ b/core/src/query-builder/in-mongo.spec.ts
@@ -1,5 +1,5 @@
 
-import { partialString } from './in-mongo';
+import { partialString, matchDate } from './in-mongo';
 
 describe('Query Builder', () => {
 
@@ -16,6 +16,14 @@ describe('Query Builder', () => {
     it('partialString: debe retornar null cuando el string es vacío', () => {
         const str = partialString('');
         expect(str).toBe('');
+    });
+
+    it('matchDate: debe retornar una expresion de comparacion de fechas', () => {
+        const str = matchDate('2019-01-01|2019-01-30');
+        expect(str).toMatchObject({
+            $gte: expect.any(Date),
+            $lte: expect.any(Date),
+        });
     });
 
 });

--- a/core/src/query-builder/in-mongo.ts
+++ b/core/src/query-builder/in-mongo.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import * as moment from 'moment';
 import { makePattern } from './utils';
 import { Types } from 'mongoose';
 import { isNullOrUndefined } from 'util';
@@ -25,6 +25,11 @@ export function matchDate(value: string) {
         } else if (value.substr(0, 1) === '<') {
             fecha = value.substr(1);
             query = { $lt: transformDate(fecha, true) };
+        } else {
+            query = {
+                $gte: transformDate(value, true),
+                $lte: transformDate(value, false)
+            };
         }
     }
     return query;

--- a/core/src/query-builder/in-mongo.ts
+++ b/core/src/query-builder/in-mongo.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import { makePattern } from './utils';
 import { Types } from 'mongoose';
 import { isNullOrUndefined } from 'util';
@@ -9,25 +9,37 @@ export function matchDate(value: string) {
     let fechas = value.split('|');
     if (fechas.length > 1) {
         query = {
-            $gte: moment(new Date(fechas[0])).toDate(),
-            $lte: moment(new Date(fechas[1])).toDate()
+            $gte: transformDate(fechas[0], true),
+            $lte: transformDate(fechas[1], false)
         };
     } else {
         if (value.substr(0, 2) === '>=') {
             fecha = value.substr(2);
-            query = { $gte: moment(new Date(fecha)).startOf('day').toDate() };
+            query = { $gte: transformDate(fecha, true) };
         } else if (value.substr(0, 1) === '>') {
             fecha = value.substr(1);
-            query = { $gt: moment(new Date(fecha)).startOf('day').toDate() };
+            query = { $gt: transformDate(fecha, true) };
         } else if (value.substr(0, 2) === '<=') {
             fecha = value.substr(2);
-            query = { $lte: moment(new Date(fecha)).startOf('day').toDate() };
+            query = { $lte: transformDate(fecha, true) };
         } else if (value.substr(0, 1) === '<') {
             fecha = value.substr(1);
-            query = { $lt: moment(new Date(fecha)).startOf('day').toDate() };
+            query = { $lt: transformDate(fecha, true) };
         }
     }
     return query;
+}
+
+export function transformDate(fecha: string, start: boolean) {
+    if (moment(fecha, 'YYYY-MM-DD', true).isValid()) {
+        if (start) {
+            return moment(fecha).startOf('day').toDate();
+        } else {
+            return moment(fecha).endOf('day').toDate();
+        }
+    } else {
+        return moment(fecha).toDate();
+    }
 }
 
 export function partialString(value: string) {

--- a/core/src/query-builder/in-mongo.ts
+++ b/core/src/query-builder/in-mongo.ts
@@ -3,11 +3,31 @@ import { makePattern } from './utils';
 import { Types } from 'mongoose';
 import { isNullOrUndefined } from 'util';
 
-export function matchDate(date: Date) {
-    return {
-        $gte: moment(date).startOf('day').toDate(),
-        $lte: moment(date).endOf('day').toDate()
-    };
+export function matchDate(value: string) {
+    let query = {};
+    let fecha;
+    let fechas = value.split('|');
+    if (fechas.length > 1) {
+        query = {
+            $gte: moment(new Date(fechas[0])).toDate(),
+            $lte: moment(new Date(fechas[1])).toDate()
+        };
+    } else {
+        if (value.substr(0, 2) === '>=') {
+            fecha = value.substr(2);
+            query = { $gte: moment(new Date(fecha)).startOf('day').toDate() };
+        } else if (value.substr(0, 1) === '>') {
+            fecha = value.substr(1);
+            query = { $gt: moment(new Date(fecha)).startOf('day').toDate() };
+        } else if (value.substr(0, 2) === '<=') {
+            fecha = value.substr(2);
+            query = { $lte: moment(new Date(fecha)).startOf('day').toDate() };
+        } else if (value.substr(0, 1) === '<') {
+            fecha = value.substr(1);
+            query = { $lt: moment(new Date(fecha)).startOf('day').toDate() };
+        }
+    }
+    return query;
 }
 
 export function partialString(value: string) {


### PR DESCRIPTION
### Requerimiento
Refactor de función de matchDate.  Permite comparar un campo entre una o dos fechas 

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Puede recibir como parámetro fechas separadas por  |  para devolver una expresión con una rango de fechas. Ej: fecha1|fecha2 
2. También se puede anteponer los símbolos (>=, >, <=, <) para devolver una expresión con un solo operador de comparación
